### PR TITLE
correct sellOrders[i].fill calculation

### DIFF
--- a/lib/engine/index.js
+++ b/lib/engine/index.js
@@ -96,7 +96,7 @@ module.exports = {
           })
           sellOrders[i].fill = sellOrders[i].quantity
         } else {
-          sellOrders[i].fill = BigNumber(sellOrders[i].quantity).minus(buyOrderQty).toString()
+          sellOrders[i].fill = buyOrderQty;
           trades.push({
             takerId: buyOrder.id,
             makerId: sellOrders[i].id,


### PR DESCRIPTION
In the esle scope sellOrders[i] is bigger than buyOrderQty, so it covers whole BuyOrderQty