### PR TITLE
correct buyOrders[i].fill caculation

### DIFF
--- a/lib/engine/index.js
+++ b/lib/engine/index.js
@@ -43,7 +43,7 @@ module.exports = {
           })
           buyOrders[i].fill = buyOrders[i].quantity
         } else {
-          buyOrders[i].fill = BigNumber(buyOrders[i].quantity).minus(sellOrderQty).toString()
+          buyOrders[i].fill = sellOrderQty;
           trades.push({
             takerId: sellOrder.id,
             makerId: buyOrders[i].id,


### PR DESCRIPTION
in the else scope "buyOrders[i].quantity" is bigger than "sellOrderQty" so "buyOrders[i].fill" is equal to sellOrderQty